### PR TITLE
Orbit Pinner Fix

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: tallylab

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-github: tallylab

--- a/lib/OrbitPinner.js
+++ b/lib/OrbitPinner.js
@@ -1,11 +1,15 @@
 'use strict'
 const OrbitDB = require('orbit-db')
 
+let orbitdb
+
 class Pinner {
   constructor (address) {
     require('./ipfsInstance').then(async (ipfs) => {
-      this.orbitdb = await OrbitDB.createInstance(ipfs)
-      Pinner.openDatabase(this.orbitdb, address)
+      if(!orbitdb) {
+        orbitdb = await OrbitDB.createInstance(ipfs)
+      }
+      Pinner.openDatabase(orbitdb, address)
     }).catch(console.error)
   }
 


### PR DESCRIPTION
**Bug:** When using the HTTP API to pin multiple addresses, the pinner will try to open an OrbitDB instance in the same directory twice, causing an `EACCESS`

This PR makes a crude "singleton" pattern by declaring the orbit instance.