### PR TITLE
static async OrbitPinner.create

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-github: tallylab

--- a/lib/OrbitPinner.js
+++ b/lib/OrbitPinner.js
@@ -1,12 +1,19 @@
 'use strict'
 const OrbitDB = require('orbit-db')
 
+let orbitdb;
+
 class Pinner {
-  constructor (address) {
-    require('./ipfsInstance').then(async (ipfs) => {
-      this.orbitdb = await OrbitDB.createInstance(ipfs)
-      Pinner.openDatabase(this.orbitdb, address)
-    }).catch(console.error)
+  constructor (db) {
+    this.db = db
+    this.address = db.id
+  }
+
+  static async create(address) {
+    const ipfs = await require('./ipfsInstance')
+    if(!orbitdb) orbitdb = await OrbitDB.createInstance(ipfs)
+    const db = await Pinner.openDatabase(orbitdb, address)
+    return Promise.resolve(new Pinner(db))
   }
 
   drop () {

--- a/lib/pinningList/index.js
+++ b/lib/pinningList/index.js
@@ -40,14 +40,15 @@ const add =
   }
 
 const createPinnerInstance =
-        address => {
+        async (address) => {
           if (!OrbitDB.isValidAddress(address)) {
             console.log(`Failed to pin ${address}. This is not a valid address`)
             return
           }
 
           console.log(`Pinning orbitdb @ ${address}`)
-          pinners[address] = new OrbitPinner(address)
+          const pinner = await OrbitPinner.create(address)
+          pinners[address] = pinner
 
           return pinners[address]
         }


### PR DESCRIPTION
This PR updates the OrbitPinner to use a static `create` function to handle the async calls needed to crate an `new OrbitPinner` 